### PR TITLE
 docs: Add OpenEdX Release Notes Checklist to Repo.

### DIFF
--- a/docs/templates/openedx-release-notes-checklist.md
+++ b/docs/templates/openedx-release-notes-checklist.md
@@ -1,0 +1,14 @@
+### Things that _can be done_ before the release is cut
+- [ ] find the date for the previous release (for Olive, this was October 11, 2022)
+- [ ] find the date for the next release (for Palm, this was April xx, 2022)
+- [ ] Create a wiki page for the _next_ release, on the [Open edX Release Planning](https://openedx.atlassian.net/wiki/spaces/COMM/pages/13205845) wiki page ([Redwood](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3890380898/Next+Release+Redwood))
+### Things to do after the release is cut
+- [ ] add an appropriate TOC to the release notes
+- [ ] add any items from the [Pending Release wiki page](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3726802953/Pending+Release+Quince)
+- [ ] Review and incorporate any feature posts from [edX Partner announcements](https://partners.edx.org/announcements)
+- [ ] Review and incorporate any feature posts from the [open edX blog](https://open.edx.org/category/blog/)
+- [ ] Review commit messages from relevant repos. [Dinghy](https://github.com/nedbat/dinghy) seems like a useful tool for this. I used this config [olive-dinghy.yaml](https://gist.github.com/pdpinch/a1749421cc2af23f9d9a2335e065489b)
+- [ ] Review [DEPR tickets ](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=452)
+- [ ] Diff the technical documentation and build a list of links to both new and removed settings. 
+### Meta tasks
+- [ ] Review and update this checklist


### PR DESCRIPTION
One item on the checklist is currently:
'Commit this checklist to a more durable location' - Github flavored Markdown is easy, accessible, and durable so it seems a good fit.