### PR TITLE
feat: add release testing label to test failure reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-failures.yml
+++ b/.github/ISSUE_TEMPLATE/test-failures.yml
@@ -1,7 +1,7 @@
 name: 📑 Test failure report
 description: Issue Template for Reporting Testing Failures.
 title: "[Test failure] <Test Case ID>: <DESCRIPTIVE TITLE>"
-labels: ["needs triage"]
+labels: ["needs triage", "release testing"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/add-label-on-failure-report.yml
+++ b/.github/workflows/add-label-on-failure-report.yml
@@ -7,11 +7,15 @@ on:
 jobs:
   add_label:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.issue.title, 'Test failure') && !contains(github.event.issue.labels.*.name, 'needs triage') && !contains(github.event.issue.labels.*.name, 'release testing') }}
+    if: ${{ contains(github.event.issue.title, 'Test failure') }}
     steps:
-      - name: Apply release testing labels
+      - if: ${{ !contains(github.event.issue.labels.*.name, 'needs triage') }}
+        name: Apply label needs triage
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: |
-            needs triage
-            release testing
+          labels: needs triage
+      - if: ${{ !contains(github.event.issue.labels.*.name, 'release testing') }}
+        name: Apply label release testing
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: release testing

--- a/.github/workflows/add-label-on-failure-report.yml
+++ b/.github/workflows/add-label-on-failure-report.yml
@@ -1,5 +1,4 @@
-
-name: Allows for the adding labels when opening a test failure issue.
+name: Allows for adding labels when opening a test failure issue.
 
 on:
   issues:
@@ -8,9 +7,11 @@ on:
 jobs:
   add_label:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.issue.title, 'Test failure') && !contains(github.event.issue.labels.*.name, 'needs triage') }}
+    if: ${{ contains(github.event.issue.title, 'Test failure') && !contains(github.event.issue.labels.*.name, 'needs triage') && !contains(github.event.issue.labels.*.name, 'release testing') }}
     steps:
-      - name: apply needs triage label
+      - name: Apply release testing labels
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: needs triage
+          labels: |
+            needs triage
+            release testing


### PR DESCRIPTION
### Description

This PR adds the `release testing` label for all testing failure reports for better trackability in the GH board.